### PR TITLE
fix: 편의시설 탭 가운데 정렬

### DIFF
--- a/frontend/src/components/BuildingInfo/BuildingDetail.jsx
+++ b/frontend/src/components/BuildingInfo/BuildingDetail.jsx
@@ -22,11 +22,13 @@ export default function BuildingDetail({ setIsDetailPage, detailPageContent }) {
         <Key>건물명</Key>
         <Val>{detailPageContent.name}</Val>
       </InfosContainer>
-      <div style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "0.3em",        
-      }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.3em",
+        }}
+      >
         {[...info].map((item, index) => {
           const key = item[0];
           const val = item[1];
@@ -50,7 +52,7 @@ const InfosContainer = styled.div`
   display: flex;
   align-items: flex-start;
   gap: 1em;
-  font-size: 14px;
+  font-size: 15px;
   &:not(:last-child) {
     margin-bottom: 7px;
   }
@@ -70,7 +72,6 @@ const Key = styled.p`
   flex: none;
   margin: 0;
   width: 6.1em;
-  text-align: start;
 `;
 const Val = styled.p`
   margin: 0;


### PR DESCRIPTION
편의시설 탭 중 건물 정보 탭에서 건물 정보가 없을 때 출력되는 문구 가운데 정렬